### PR TITLE
不要な変更を削除: 更新間隔が長いデータの最終更新日はデータのビルドの時に日付のみを取得するようにする

### DIFF
--- a/components/cards/ConsultsNumberCard.vue
+++ b/components/cards/ConsultsNumberCard.vue
@@ -21,7 +21,6 @@
 </i18n>
 
 <script>
-import moment from 'moment'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -38,8 +37,6 @@ export default {
       Data,
       consultsGraph
     }
-    // 更新頻度が少ないデータは最終更新日の表示に留める
-    data.Data.consults.date = moment(Data.querents.date).format('YYYY/MM/DD')
     return data
   }
 }

--- a/components/cards/QuerentsNumberCard.vue
+++ b/components/cards/QuerentsNumberCard.vue
@@ -21,7 +21,6 @@
 </i18n>
 
 <script>
-import moment from 'moment'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -38,8 +37,6 @@ export default {
       Data,
       querentsGraph
     }
-    // 更新頻度が少ないデータは最終更新日の表示に留める
-    data.Data.querents.date = moment(Data.querents.date).format('YYYY/MM/DD')
     return data
   }
 }

--- a/components/cards/TestsNumberCard.vue
+++ b/components/cards/TestsNumberCard.vue
@@ -21,7 +21,6 @@
 </i18n>
 
 <script>
-import moment from 'moment'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -38,8 +37,6 @@ export default {
       Data,
       testsGraph
     }
-    // 更新頻度が少ないデータは最終更新日の表示に留める
-    data.Data.tests.date = moment(Data.querents.date).format('YYYY/MM/DD')
     return data
   }
 }


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
- 不要な処理を削除
- @YuseiIto に generateData.js へ追加していただいた機能と重複しているため
